### PR TITLE
Check for 64 bit lib mqm availability

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ task :gem  do |t|
   ]
 
   gemspec = Gem::Specification.new do |spec|
-    spec.name              = 'ekaranto-rubywmq'
+    spec.name              = 'rubywmq'
     spec.version           = WMQ::VERSION
     spec.platform          = Gem::Platform::RUBY
     spec.authors           = ['Reid Morrison', 'Edwin Fine']
@@ -52,7 +52,7 @@ task :binary  do |t|
   FileUtils.copy('ext/wmq.so', 'lib/wmq/wmq.so')
 
   gemspec = Gem::Specification.new do |spec|
-    spec.name              = 'ekaranto-rubywmq'
+    spec.name              = 'rubywmq'
     spec.version           = WMQ::VERSION
     spec.platform          = Gem::Platform::CURRENT
     spec.authors           = ['Reid Morrison', 'Edwin Fine']

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -11,7 +11,9 @@ if RUBY_PLATFORM =~ /win|mingw/i
   dir_config('mqm', include_path, '.')
 else
   include_path = '/opt/mqm/inc'
-  dir_config('mqm', include_path, '/opt/mqm/lib64')
+  lib64_path   = '/opt/mqm/lib64'
+  lib_path     = File.directory?(lib64_path) ? lib64_path : '/opt/mqm/lib'
+  dir_config('mqm', include_path, lib_path)
 end
 
 have_header('cmqc.h')


### PR DESCRIPTION
Hi,

We use rubywmq as a gem dependency on 64 bit client servers. To ensure it installs correctly I've changed it to check if a `lib64` directory exists already, if so use that, if not apply the default `/opt/mqm/lib`.

Thanks for a great gem!

Cheers,

Tom
