### PR TITLE
Add a new queue manager connect option: use_system_connection_data

### DIFF
--- a/ext/wmq_queue_manager.c
+++ b/ext/wmq_queue_manager.c
@@ -1188,6 +1188,12 @@ static VALUE QueueManager_singleton_connect_ensure(VALUE self)
  *   * Default Value:
  *       WMQ::MQXPT_TCP
  *
+ * * :use_system_connection_data => Boolean
+ *   * Used when you want to initialise a client connection, but you want
+ *   * to obtain the connection_name and channel_name from one of the system
+ *   * configuration methods. These being: mqclient.ini file, MQSERVER ENV
+ *   * variable or CCDT.
+ *
  * For the Advanced Client Connection parameters, please see the WebSphere MQ documentation
  *
  * Note:


### PR DESCRIPTION
It is used when you want to initialise a client connection, but you want
to obtain the `connection_name` and `channel_name` from one of the system
configuration methods. These being: mqclient.ini file, MQSERVER ENV
variable or CCDT.

Sample usage:

```
WMQ::QueueManager.connect(q_mgr_name: "*SOME_Q_MGR", use_system_connection_data: true) do |queue_manager|
  ...
end
```
