### PR TITLE
Fixed loading of MQClient Library on Windows x64

### DIFF
--- a/ext/wmq_mq_load.c
+++ b/ext/wmq_mq_load.c
@@ -41,7 +41,11 @@
         }
 
     #define MQ_LIBRARY_SERVER "mqm"
-    #define MQ_LIBRARY_CLIENT "mqic32"
+    #ifdef _WIN64
+        #define MQ_LIBRARY_CLIENT "mqic"
+    #else
+        #define MQ_LIBRARY_CLIENT "mqic32"
+    #endif
 #elif defined(SOLARIS) || defined(__SVR4) || defined(__linux__) || defined(LINUX)
     /*
      * SOLARIS, LINUX


### PR DESCRIPTION
On Windows x64 the mqic32.dll Library cannot be loaded because of the Architecture mismatch