### PR TITLE
Fix descriptor initialization

### DIFF
--- a/ext/wmq_message.c
+++ b/ext/wmq_message.c
@@ -238,7 +238,7 @@ VALUE Message_initialize(int argc, VALUE *argv, VALUE self)
         val = rb_hash_aref(parms, ID2SYM(ID_descriptor));
         if (NIL_P(val))
         {
-            rb_iv_set(self, "@headers", rb_hash_new());
+            rb_iv_set(self, "@descriptor", rb_hash_new());
         }
         else
         {


### PR DESCRIPTION
Hello!

I want to fix a typo in C code that leads to `@descriptor` is not initialized if calling `WMQ::Message.new(...)` with parameters.