### PR TITLE
fixed remote queue name

### DIFF
--- a/ext/wmq_queue_manager.c
+++ b/ext/wmq_queue_manager.c
@@ -815,7 +815,7 @@ VALUE QueueManager_put(VALUE self, VALUE hash)
     {
         WMQ_HASH2MQCHARS(q_name, q_mgr_name, od.ObjectQMgrName)
 
-        q_name = rb_hash_aref(val, ID2SYM(ID_q_name));
+        q_name = rb_hash_aref(q_name, ID2SYM(ID_q_name));
         if (NIL_P(q_name))
         {
             rb_raise(rb_eArgError,

--- a/lib/wmq/queue_manager.rb
+++ b/lib/wmq/queue_manager.rb
@@ -64,11 +64,15 @@ module WMQ
           reply.descriptor[:msg_id] = request.descriptor[:msg_id]
         end
 
-        parms[:q_name]    = request.descriptor[:reply_to_q]
-        parms[:q_mgr_name]= request.descriptor[:reply_to_q_mgr]
-        return put(parms)
+        q_name = {
+            q_name:     request.descriptor[:reply_to_q],
+            q_mgr_name: request.descriptor[:reply_to_q_mgr]
+        }
+
+        parms[:q_name] = q_name
+        put(parms)
       else
-        return false
+        false
       end
     end
 


### PR DESCRIPTION
Fixed a bug where the reply_to_q_mgr was being set in the wrong place.  After fixing this there was a segfault in wmq_queue_manager.c as the wrong hash was being read.
